### PR TITLE
P47からシングルクォーテーションを削除

### DIFF
--- a/copy_text.md
+++ b/copy_text.md
@@ -105,7 +105,7 @@ git push heroku master
 ## P.45
 
 ```
-heroku config:set APPLICATION_ID='スキルのExtension ID' -a herokuのアプリ名
+heroku config:set APPLICATION_ID=スキルのExtensionID -a herokuのアプリ名
 ```
 
 ## P.47


### PR DESCRIPTION
P47からシングルクォーテーションを外し、'スキルのExtension ID' のIDが引数にみえるので　「スキルのExtensionID」にまとめました。